### PR TITLE
Add blacklisted topics

### DIFF
--- a/rosbag2_snapshot/include/rosbag2_snapshot/snapshotter.hpp
+++ b/rosbag2_snapshot/include/rosbag2_snapshot/snapshotter.hpp
@@ -131,6 +131,8 @@ struct SnapshotterOptions
   // Provides list of topics to snapshot and their limit configurations
   topics_t topics_;
 
+  topics_t blacklist_topics_;
+
   SnapshotterOptions(
     rclcpp::Duration default_duration_limit = rclcpp::Duration(30s),
     int32_t default_memory_limit = -1);


### PR DESCRIPTION
## Purpose

Sometimes we do not want to record some heavy topics like `Image` or `Pointcloud`.

## Approach

Add ROS param `blacklist_topics`. If any of existing topics is in that list, do not subscribe to it.

## Disclaimers

That implementation is not able to subscribe to the topics with non-default QoS policy, which makes it unable to subscribe to some sensor data (Imu, Images). So I add dirty fix for that [here](https://github.com/cmrobotics/rosbag2_snapshot/blob/d6260e0ffec830b3e7c1f5599222ac0d0328cc15/rosbag2_snapshot/src/snapshotter.cpp#L469). Allow it to live here, please, until I return back with proper fix like described in this [issue](https://github.com/gaia-platform/rosbag2_snapshot/issues/7).
 