### PR TITLE
humble migration (SS-145)

### DIFF
--- a/rosbag2_snapshot/src/snapshotter.cpp
+++ b/rosbag2_snapshot/src/snapshotter.cpp
@@ -26,7 +26,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include <rclcpp/scope_exit.hpp>
+#include <rcpputils/scope_exit.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <rosbag2_snapshot/snapshotter.hpp>
 
@@ -535,7 +535,7 @@ void Snapshotter::triggerSnapshotCb(
   }
 
   // Ensure that state is updated when function exits, regardlesss of branch path / exception events
-  RCLCPP_SCOPE_EXIT(
+  RCPPUTILS_SCOPE_EXIT(
     // Clear buffers beacuase time gaps (skipped messages) may have occured while paused
     std::unique_lock<std::shared_mutex> write_lock(state_lock_);
     // Turn off writing flag and return recording to its state before writing


### PR DESCRIPTION
Changes done during our migration to ros2 humble. 
rclcpp/scope_exit is deprecated and generates build warnings.

We are using rcpputils/scope_exit instead.